### PR TITLE
Get `cargo build` working

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,41 @@
 # Funhouse
 
-A GitHub mirror that responds to webhook invocations from GitHub to mirror the
-repository on-demand.
+A collection of distorted Git mirrors
+
+## Building/Running FUSE mirror
+
+1. Have a Linux machine with Bazel installed
+
+1. Start the server, passing a URL to a public GitHub repository:
+
+   ```
+   bazel run //server:funhouse_server -- \
+     --grpc_port=8080 \
+     --base_path=/tmp/funhouse_data \
+     --repo_url=https://github.com/minorhacks/advent_2020 \
+     --alsologtostderr \
+     --v=1
+   ```
+
+1. Start the client, passing the address to the server, as well as the directory
+   to mount to:
+
+   ```
+   bazel run //client -- \
+     --mount_point=/tmp/funhouse \
+     --server_addr=localhost:8080 \
+     --alsologtostderr
+   ```
+
+1. List files in a particular commit: `ls -la
+   /tmp/funhouse/commits/0802d5e6cee084a8f867c5406e46a3fca556bf4e`
+
+1. Run a build from a particular commit:
+
+   NOTE: Writes in-tree will fail with `EROFS` (read-only filesystem) so build
+   tools must be configured to produce build artifacts out-of-tree
+
+   ```
+   # The example is a Rust repo, so with the proper Rust tooling installed:
+   CARGO_TARGET_DIR=/tmp/rust_build_out cargo build
+   ```

--- a/fuse/BUILD.bazel
+++ b/fuse/BUILD.bazel
@@ -15,5 +15,7 @@ go_library(
         "@com_github_hanwen_go_fuse//fuse",
         "@com_github_hanwen_go_fuse//fuse/nodefs",
         "@com_github_hanwen_go_fuse//fuse/pathfs",
+        "@org_golang_google_grpc//codes:go_default_library",
+        "@org_golang_google_grpc//status:go_default_library",
     ],
 )

--- a/service/BUILD.bazel
+++ b/service/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
     importpath = "github.com/minorhacks/funhouse/service",
     visibility = ["//visibility:public"],
     deps = [
-        "//github",
         "//proto:git_read_fs_proto_go_proto",
         "@com_github_go_git_go_git_v5//:go-git",
         "@com_github_go_git_go_git_v5//config",
@@ -17,7 +16,6 @@ go_library(
         "@com_github_go_git_go_git_v5//plumbing/filemode",
         "@com_github_go_git_go_git_v5//plumbing/object",
         "@com_github_golang_glog//:glog",
-        "@com_github_kylelemons_godebug//pretty",
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
         "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",


### PR DESCRIPTION
`cargo build` now successfully builds a mirrored Rust repo, as long as
Cargo is configured to write artifacts out-of-tree.

This change also contains a README revamp to make getting started
easier.