### PR TITLE
client: Add flag to enable insecure gRPC communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A collection of distorted Git mirrors
    bazel run //client -- \
      --mount_point=/tmp/funhouse \
      --server_addr=localhost:8080 \
+     --insecure \
      --alsologtostderr
    ```
 


### PR DESCRIPTION
Prior to this change, the client always looked to make TLS gRPC channels
with the specified server. This allows for plaintext gRPC to be used
instead when `--insecure` is passed to the client.